### PR TITLE
Support for wide crate on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/lunuy/fast-svd-3x3"
 keywords = ["math", "svd", "simd"]
 
 [dependencies]
+wide = { version = "0.7", optional = true }
 
 [dev-dependencies]
 rand = "0.9.1"
@@ -20,3 +21,4 @@ sse = []
 avx = []
 avx512 = []
 portable_simd = []
+wide = ["dep:wide"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ pub mod traits;
 pub use svd::{svd};
 pub use utils::{svd_mat};
 
+#[cfg(feature = "wide")]
+pub use wide::f32x8;
+
 // Tests
 #[cfg(test)]
 mod tests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-#![feature(portable_simd)]
-#![feature(stdarch_x86_avx512)]
+#![cfg_attr(feature = "portable_simd", feature(portable_simd))]
+#![cfg_attr(feature = "avx512", feature(stdarch_x86_avx512))]
 
 mod jacobi_conjugation;
 mod givens_qr_factorization;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,7 @@
-use std::{arch::x86_64::{__m256, _mm256_set_ps, _mm256_setzero_ps, _mm256_storeu_ps}, hint::black_box, ops::Range, simd::{f32x8, LaneCount, Simd, SupportedLaneCount}};
+use std::{arch::x86_64::{__m256, _mm256_set_ps, _mm256_setzero_ps, _mm256_storeu_ps}, hint::black_box, ops::Range};
+
+#[cfg(feature = "portable_simd")]
+use std::{simd::{f32x8, LaneCount, Simd, SupportedLaneCount}};
 
 use rand::{rngs::ThreadRng, Rng};
 
@@ -27,6 +30,7 @@ fn randoms_m256(length: usize, range: Range<f32>, rng: &mut ThreadRng) -> Vec<__
     }
 }
 
+#[cfg(feature = "portable_simd")]
 fn randoms_portable_simd<const N: usize>(length: usize, range: Range<f32>, rng: &mut ThreadRng) -> Vec<Simd<f32, N>>
 where
     LaneCount<N>: SupportedLaneCount,

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -8,6 +8,8 @@ mod __m256;
 mod __m512;
 #[cfg(feature = "portable_simd")]
 mod portable_simd;
+#[cfg(feature = "wide")]
+mod wide;
 
 pub trait SVDCompatible {
     type Mask;

--- a/src/traits/wide.rs
+++ b/src/traits/wide.rs
@@ -1,0 +1,86 @@
+use super::SVDCompatible;
+use std::ops::{BitAnd, BitXor};
+use wide::{CmpGe, CmpLe, CmpLt, f32x8};
+
+impl SVDCompatible for f32x8 {
+    type Mask = f32x8;
+    #[inline(always)]
+    fn default() -> Self {
+        Default::default()
+    }
+
+    #[inline(always)]
+    fn add(&self, other: &Self) -> Self {
+        *self + *other
+    }
+
+    #[inline(always)]
+    fn sub(&self, other: &Self) -> Self {
+        *self - *other
+    }
+
+    #[inline(always)]
+    fn mul(&self, other: &Self) -> Self {
+        *self * *other
+    }
+
+    #[inline(always)]
+    fn max(&self, other: &Self) -> Self {
+        Self::max(*self, *other)
+    }
+
+    #[inline(always)]
+    fn and(&self, other: &Self) -> Self {
+        self.bitand(other)
+    }
+
+    #[inline(always)]
+    fn xor(&self, other: &Self) -> Self {
+        self.bitxor(other)
+    }
+
+    #[inline(always)]
+    fn cmpge(&self, other: &Self) -> Self::Mask {
+        self.cmp_ge(*other)
+    }
+
+    #[inline(always)]
+    fn cmple(&self, other: &Self) -> Self::Mask {
+        self.cmp_le(*other)
+    }
+
+    #[inline(always)]
+    fn cmplt(&self, other: &Self) -> Self::Mask {
+        self.cmp_lt(*other)
+    }
+
+    #[inline(always)]
+    fn splat(value: f32) -> Self {
+        Self::splat(value)
+    }
+
+    #[inline(always)]
+    fn rsqrt(&self) -> Self {
+        self.recip_sqrt()
+    }
+
+    #[inline(always)]
+    fn clone(&self) -> Self {
+        *self
+    }
+
+    #[inline(always)]
+    fn blend(mask: &Self::Mask, other_false: &Self, other_true: &Self) -> Self {
+        mask.blend(*other_true, *other_false)
+    }
+
+    #[inline(always)]
+    fn maskz(mask: &Self::Mask, other: &Self) -> Self {
+        mask.blend(*other, Self::splat(0.0))
+    }
+
+    #[inline(always)]
+    fn ones() -> Self {
+        Self::splat(f32::from_bits(0xFFFFFFFF))
+    }
+}


### PR DESCRIPTION
Optional support (with feature flag) for f32x8 from the wide crate on stable Rust. Performance should be only slightly worse (~4% slower on my machine) than AVX2 and significantly faster than Portable SIMD.